### PR TITLE
Fix lxml version selector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 cryptography = "^2.8"
-lxml = "4.4.1"
+lxml = "^4.4.1"
 defusedxml = "^0.6.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
lxml was incorrectly locked to 4.4.1 specifically, this allows other versions.