### PR TITLE
Fix handling of base64Binary content

### DIFF
--- a/src/minisignxml/internal/utils.py
+++ b/src/minisignxml/internal/utils.py
@@ -122,3 +122,13 @@ def remove_preserving_whitespace(element: Element) -> None:
         else:
             parent.text = (parent.text or "") + element.tail
     parent.remove(element)
+
+
+def base64_binary_content(element: Element) -> bytes:
+    return base64.b64decode(
+        element.text.replace("\n", "")
+        .replace("\r", "")
+        .replace("\t", "")
+        .replace(" ", ""),
+        validate=True,
+    )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,4 +1,5 @@
 import binascii
+import textwrap
 from typing import Tuple
 
 import pytest
@@ -22,12 +23,8 @@ from minisignxml.verify import (
     extract_verified_element_and_certificate,
 )
 
-
-@pytest.fixture
-def cert_and_signed() -> Tuple[Certificate, bytes]:
-    return (
-        load_pem_x509_certificate(
-            b"""-----BEGIN CERTIFICATE-----
+_cert_obj = load_pem_x509_certificate(
+    b"""-----BEGIN CERTIFICATE-----
 MIICqjCCAZKgAwIBAgIUVm184XOVf+ZSmOo+MjOT3MIzdSIwDQYJKoZIhvcNAQEL
 BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAxMTUwNzA4MDhaFw0yMDAxMTYwNzA4
 MDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
@@ -44,37 +41,49 @@ SB9HhQm6oxf8Z4zAPbAJu2mbxI+wcT40Mbw9BhJR/mb1eGMUtetzp7G1btYUtlH4
 Yix0bP72mabQDIRoQjs8bd2/5nkXLPsCB5nUXp0dbIhYk2Qb0iNgzYdDleLS3pIc
 EWcj4VxjuYBtQyxhyko=
 -----END CERTIFICATE-----""",
-            default_backend(),
-        ),
-        (
-            b'<test:root xmlns:test="urn:test">'
-            b'<test:signed ID="test">'
-            b'<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">'
-            b"<ds:SignedInfo>"
-            b'<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>'
-            b'<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>'
-            b'<ds:Reference URI="#test">'
-            b"<ds:Transforms>"
-            b'<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>'
-            b'<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform>'
-            b"</ds:Transforms>"
-            b'<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"></ds:DigestMethod>'
-            b"<ds:DigestValue>KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI=</ds:DigestValue>"
-            b"</ds:Reference>"
-            b"</ds:SignedInfo>"
-            b"<ds:SignatureValue>pvAdYfF2NtS3Dm8/4zP1vcxs4G6IpApn0Nl0Wg930fJm7uBC7M4E7RdwiMav9UkYVK8cNrNhUnpsWEwX5anE8JOZLnW9JZ8W4a/i8ZFD7KA8PKu6q9I7HxT7eOdjgVUvZkL6j8Jz0Mf97GPc1mpU1Dyvn4qvnXS7iy6g4tuAYeArKYKJHpXqzE3YEoXnnWOwxf44Tw92YVAPO0fvVJUKY2Nt1Om/QX6oZbpwooJN3iBPgu0Zq805d4rT8J01571flyr0+HWPYDN8Q7iPuZC+zPwzyzMFdOyjbS30qRrtvUf/0gDap+s3Kl0U0AiywSrdhzyyc/5cOrOhbEwDu+8+Uw==</ds:SignatureValue>"
-            b"<ds:KeyInfo>"
-            b"<ds:X509Data>"
-            b"<ds:X509Certificate>MIICqjCCAZKgAwIBAgIUVm184XOVf+ZSmOo+MjOT3MIzdSIwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAxMTUwNzA4MDhaFw0yMDAxMTYwNzA4MDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8IAf7PQxlUTeDZodyCdaTY/XtCNBLI5FNGKgVbjePSDDlsn4nBAtaPemGLNof0lPr4sRjdC5rfwQVtDU21GJMam106RvJcg4eYns51Y2CshDpu6M9Il96Qrp+9djcdbH0MHPsenR+ChTmKa6XYfRkPCO8WIp08Tl39kP0LJNHKcT9OAc6QlS3igcIsL2dkiz6Xq7dVgZ27aViz1pWqdxuqfbSOKQSPqcQRGE8spt9KU+r5UFH4z4ZXGuml/YwscEVKgpzNYdlqE8OpKurm3+pNDuxpbTK+P9Wz0Gq1z5QNP0epaM3bVN0Ft6SH+y+Pyo5ueX7raGB8HXwqgqI6xOBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFCbgyUX+Lj2gpx0VqXiYZ8ZCGq644EENsCDHV1fnSq/KuLDuajao6ppEubl5XDs0fba1jy3aJ30H0vuVJ1eLnpOrh/xpAUtpwr9T98kLilRWEGgAKQTl7dilKkYJ1sBA1OUv6ERRt+I7NnMXQvvz2VfevulVHQnO1Reo/QCfMrVdVGTfrYkKRzAnxH/g259+RzpSB9HhQm6oxf8Z4zAPbAJu2mbxI+wcT40Mbw9BhJR/mb1eGMUtetzp7G1btYUtlH4Yix0bP72mabQDIRoQjs8bd2/5nkXLPsCB5nUXp0dbIhYk2Qb0iNgzYdDleLS3pIcEWcj4VxjuYBtQyxhyko="
-            b"</ds:X509Certificate>"
-            b"</ds:X509Data>"
-            b"</ds:KeyInfo>"
-            b"</ds:Signature>"
-            b"<test:content>Value</test:content>"
-            b"</test:signed>"
-            b"</test:root>"
-        ),
-    )
+    default_backend(),
+)
+
+_sig = "pvAdYfF2NtS3Dm8/4zP1vcxs4G6IpApn0Nl0Wg930fJm7uBC7M4E7RdwiMav9UkYVK8cNrNhUnpsWEwX5anE8JOZLnW9JZ8W4a/i8ZFD7KA8PKu6q9I7HxT7eOdjgVUvZkL6j8Jz0Mf97GPc1mpU1Dyvn4qvnXS7iy6g4tuAYeArKYKJHpXqzE3YEoXnnWOwxf44Tw92YVAPO0fvVJUKY2Nt1Om/QX6oZbpwooJN3iBPgu0Zq805d4rT8J01571flyr0+HWPYDN8Q7iPuZC+zPwzyzMFdOyjbS30qRrtvUf/0gDap+s3Kl0U0AiywSrdhzyyc/5cOrOhbEwDu+8+Uw=="
+_cert_der = "MIICqjCCAZKgAwIBAgIUVm184XOVf+ZSmOo+MjOT3MIzdSIwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAxMTUwNzA4MDhaFw0yMDAxMTYwNzA4MDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8IAf7PQxlUTeDZodyCdaTY/XtCNBLI5FNGKgVbjePSDDlsn4nBAtaPemGLNof0lPr4sRjdC5rfwQVtDU21GJMam106RvJcg4eYns51Y2CshDpu6M9Il96Qrp+9djcdbH0MHPsenR+ChTmKa6XYfRkPCO8WIp08Tl39kP0LJNHKcT9OAc6QlS3igcIsL2dkiz6Xq7dVgZ27aViz1pWqdxuqfbSOKQSPqcQRGE8spt9KU+r5UFH4z4ZXGuml/YwscEVKgpzNYdlqE8OpKurm3+pNDuxpbTK+P9Wz0Gq1z5QNP0epaM3bVN0Ft6SH+y+Pyo5ueX7raGB8HXwqgqI6xOBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFCbgyUX+Lj2gpx0VqXiYZ8ZCGq644EENsCDHV1fnSq/KuLDuajao6ppEubl5XDs0fba1jy3aJ30H0vuVJ1eLnpOrh/xpAUtpwr9T98kLilRWEGgAKQTl7dilKkYJ1sBA1OUv6ERRt+I7NnMXQvvz2VfevulVHQnO1Reo/QCfMrVdVGTfrYkKRzAnxH/g259+RzpSB9HhQm6oxf8Z4zAPbAJu2mbxI+wcT40Mbw9BhJR/mb1eGMUtetzp7G1btYUtlH4Yix0bP72mabQDIRoQjs8bd2/5nkXLPsCB5nUXp0dbIhYk2Qb0iNgzYdDleLS3pIcEWcj4VxjuYBtQyxhyko="
+
+_signed = lambda sig, cert: (
+    b'<test:root xmlns:test="urn:test">'
+    b'<test:signed ID="test">'
+    b'<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">'
+    b"<ds:SignedInfo>"
+    b'<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>'
+    b'<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>'
+    b'<ds:Reference URI="#test">'
+    b"<ds:Transforms>"
+    b'<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>'
+    b'<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform>'
+    b"</ds:Transforms>"
+    b'<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"></ds:DigestMethod>'
+    b"<ds:DigestValue>KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI=</ds:DigestValue>"
+    b"</ds:Reference>"
+    b"</ds:SignedInfo>"
+    b"<ds:SignatureValue>" + sig + b"</ds:SignatureValue>"
+    b"<ds:KeyInfo>"
+    b"<ds:X509Data>"
+    b"<ds:X509Certificate>" + cert + b"</ds:X509Certificate>"
+    b"</ds:X509Data>"
+    b"</ds:KeyInfo>"
+    b"</ds:Signature>"
+    b"<test:content>Value</test:content>"
+    b"</test:signed>"
+    b"</test:root>"
+)
+
+
+def _pretty_b64(val: str) -> bytes:
+    return b"\n".join(map(str.encode, textwrap.wrap(val, width=79)))
+
+
+@pytest.fixture(scope="session", params=[True, False])
+def cert_and_signed(request) -> Tuple[Certificate, bytes]:
+    transform = _pretty_b64 if request.param else str.encode
+    return _cert_obj, _signed(transform(_sig), transform(_cert_der))
 
 
 def test_verify(xmlsec1, tmp_path, cert_and_signed):


### PR DESCRIPTION
Fixes #7


According to the spec [1] base64 binary content in the signature should
strip whitespace (newline, carrier feed, tab, space) before decoding
base64 content.

[1] https://www.w3.org/TR/xmlschema-2/#base64Binary