### PR TITLE
Fix verification with SHA1 Signature Method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ jobs:
       - run:
           xmlsec1 --version
       - run:
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          curl -sSL https://install.python-poetry.org | python -
       - run:
-          $HOME/.poetry/bin/poetry install
+          $HOME/.local/bin/poetry install --no-ansi
       - run:
-          $HOME/.poetry/bin/poetry run pytest
+          $HOME/.local/bin/poetry run pytest
       - run:
-          $HOME/.poetry/bin/poetry run black --check .
+          $HOME/.local/bin/poetry run black --check .
       - run:
-          $HOME/.poetry/bin/poetry run isort --check-only .
+          $HOME/.local/bin/poetry run isort --check-only .
       - run:
-          $HOME/.poetry/bin/poetry run mypy src
+          $HOME/.local/bin/poetry run mypy src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,24 @@
 repos:
--   repo: git://github.com/psf/black
-    rev: 21.9b0
-    hooks:
-    - id: black
--   repo: https://github.com/pycqa/isort
-    rev: 5.9.3
-    hooks:
-      - id: isort
 -   repo: local
     hooks:
+    -   id: black
+        name: black
+        entry: poetry run black src stubs tests
+        language: system
+        require_serial: true
+        types: [python]
+        pass_filenames: false
+    -   id: isort
+        name: isort
+        entry: poetry run isort
+        language: system
+        types: [python]
+        require_serial: true
+        args: ['--filter-files']
+        files: "^(src/.*\\.py|tests/.*\\.py|stubs/.*\\.py)"
     -   id: mypy
         name: mypy
-        entry: poetry run mypy src
+        entry: poetry run mypy
         language: system
         types: [python]
         pass_filenames: false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,0 @@
-[mypy]
-strict = true
-
-[mypy-lxml.*]
-ignore_missing_imports = true
-
-[mypy-defusedxml.lxml]
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.8",
@@ -27,19 +28,24 @@ cryptography = ">=2.8"
 lxml = ">=4.4.1"
 defusedxml = ">=0.6.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=5.2"
-black = ">=21.9b0"
-isort = ">=5.8.0"
+black = "^23"
+isort = "^5"
 pytest-cov = ">=2.8.1"
-mypy = ">=0.782"
+mypy = "^1"
+lxml-stubs = "^0.4.0"
 
 [tool.isort]
-line_length = "88"
-multi_line_output = "3"
-combine_as_imports = "1"
-include_trailing_comma = "True"
+profile = "black"
+
+[tool.mypy]
+strict = true
+files = [
+    "src/",
+]
+mypy_path = "stubs/"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/src/minisignxml/internal/utils.py
+++ b/src/minisignxml/internal/utils.py
@@ -8,7 +8,8 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPubl
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 from cryptography.x509 import Certificate
 from defusedxml.lxml import fromstring
-from lxml.etree import _Element as Element, tostring
+from lxml.etree import _Element as Element
+from lxml.etree import tostring
 
 from ..errors import (
     ElementNotFound,
@@ -36,7 +37,7 @@ def signature_method_algorithm(hasher: HashAlgorithm) -> str:
 
 
 def signature_method_hasher(algorithm: str) -> HashAlgorithm:
-    if algorithm == XMLDSIG_SHA1:
+    if algorithm == XMLDSIG_RSA_SHA1:
         return hashes.SHA1()
     elif algorithm == XMLDSIG_RSA_SHA256:
         return hashes.SHA256()
@@ -115,6 +116,7 @@ def get_root(element: Element) -> Element:
 
 def remove_preserving_whitespace(element: Element) -> None:
     parent = element.getparent()
+    assert parent
     if element.tail:
         prev = element.getprevious()
         if prev is not None:
@@ -126,7 +128,8 @@ def remove_preserving_whitespace(element: Element) -> None:
 
 def base64_binary_content(element: Element) -> bytes:
     return base64.b64decode(
-        element.text.replace("\n", "")
+        (element.text or "")
+        .replace("\n", "")
         .replace("\r", "")
         .replace("\t", "")
         .replace(" ", ""),

--- a/src/minisignxml/sign.py
+++ b/src/minisignxml/sign.py
@@ -26,6 +26,8 @@ def sign(
         element_id = element.attrib["ID"]
     except KeyError:
         raise NoIDAttribute(element)
+    if not isinstance(element_id, str):
+        raise TypeError()
     # Generate the digest value of the element/content to be signed
     content_digest_value = utils.ascii_b64(
         utils.hash_digest(config.digest_method, utils.serialize_xml(element))

--- a/stubs/defusedxml/lxml.pyi
+++ b/stubs/defusedxml/lxml.pyi
@@ -1,0 +1,11 @@
+from typing import Union
+
+from lxml.etree import XMLParser, _Element
+
+def fromstring(
+    text: Union[str, bytes],
+    parser: XMLParser = ...,
+    base_url: Union[str, bytes] = ...,
+    forbid_dtd: bool = ...,
+    forbid_entities: bool = ...,
+) -> _Element: ...

--- a/stubs/lxml/builder.pyi
+++ b/stubs/lxml/builder.pyi
@@ -1,0 +1,28 @@
+from typing import Any, Callable, Optional, Protocol
+
+from lxml.etree import _Element
+
+class ElementMakerProtocol(Protocol):
+    def __call__(self, *children: Any, **attrib: str) -> _Element: ...
+
+class MakeElementProtocol(Protocol):
+    def __call__(
+        self,
+        tag: str,
+        attrib: Optional[dict[str, str]] = ...,
+        nsmap: Optional[dict[str, str]] = ...,
+        **extra: Any
+    ) -> _Element: ...
+
+class ElementMaker:
+    def __init__(
+        self,
+        typemap: Optional[dict[Any, Callable[[_Element, Any], None]]] = ...,
+        namespace: Optional[str] = ...,
+        nsmap: Optional[dict[str, str]] = ...,
+        makeelement: Optional[MakeElementProtocol] = ...,
+    ): ...
+    def __call__(self, tag: str, *children: Any, **attrib: str) -> _Element: ...
+    def __getattr__(self, tag: str) -> ElementMakerProtocol: ...
+
+E: ElementMaker

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,9 +1,11 @@
+import base64
 import binascii
+import itertools
 import textwrap
+from dataclasses import dataclass
 from typing import Tuple
 
 import pytest
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, load_pem_x509_certificate
@@ -23,44 +25,75 @@ from minisignxml.verify import (
     extract_verified_element_and_certificate,
 )
 
-_cert_obj = load_pem_x509_certificate(
-    b"""-----BEGIN CERTIFICATE-----
-MIICqjCCAZKgAwIBAgIUVm184XOVf+ZSmOo+MjOT3MIzdSIwDQYJKoZIhvcNAQEL
-BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAxMTUwNzA4MDhaFw0yMDAxMTYwNzA4
-MDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQC8IAf7PQxlUTeDZodyCdaTY/XtCNBLI5FNGKgVbjePSDDlsn4nBAtaPemG
-LNof0lPr4sRjdC5rfwQVtDU21GJMam106RvJcg4eYns51Y2CshDpu6M9Il96Qrp+
-9djcdbH0MHPsenR+ChTmKa6XYfRkPCO8WIp08Tl39kP0LJNHKcT9OAc6QlS3igcI
-sL2dkiz6Xq7dVgZ27aViz1pWqdxuqfbSOKQSPqcQRGE8spt9KU+r5UFH4z4ZXGum
-l/YwscEVKgpzNYdlqE8OpKurm3+pNDuxpbTK+P9Wz0Gq1z5QNP0epaM3bVN0Ft6S
-H+y+Pyo5ueX7raGB8HXwqgqI6xOBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFCb
-gyUX+Lj2gpx0VqXiYZ8ZCGq644EENsCDHV1fnSq/KuLDuajao6ppEubl5XDs0fba
-1jy3aJ30H0vuVJ1eLnpOrh/xpAUtpwr9T98kLilRWEGgAKQTl7dilKkYJ1sBA1OU
-v6ERRt+I7NnMXQvvz2VfevulVHQnO1Reo/QCfMrVdVGTfrYkKRzAnxH/g259+Rzp
-SB9HhQm6oxf8Z4zAPbAJu2mbxI+wcT40Mbw9BhJR/mb1eGMUtetzp7G1btYUtlH4
-Yix0bP72mabQDIRoQjs8bd2/5nkXLPsCB5nUXp0dbIhYk2Qb0iNgzYdDleLS3pIc
-EWcj4VxjuYBtQyxhyko=
------END CERTIFICATE-----""",
-    default_backend(),
-)
+_private_key = b"""-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDW5mB4IVP4ASCr
+PKW5vQLAeqDRnpqepjvyqs9rByTNENBzvUUni1jHGAmmmT0QweFYaIW7n2CPynN4
+PJRfmdI2Qkj8w6im0NYKGUYoyKy9XC8WMBqKEFBsFt/ByfJYtZncjPYpvBR3jQbZ
+ft2FeqNQmUv6GXQA5ul/IifmYnWuDguzlzJklfejOD3YwadMxt7TnMPGxtBpA7IA
+icheLTFu25GL+KQmOJ5/aaGRgS821SwKAAGAXBvUTAa6swREhaxx8eo0qg1B/bJa
+4BnuMj5y2nxAe1CbiQcOJg09NQcRQFtjBIlr3B6kCLDsDfSJffL1sIiHo8tgAtFa
+DwupJ4wrAgMBAAECggEAActx+3OPVSt0iQIJcvy+jjoyTXRy1/L+OKUn5adAD6K3
+/U0bNT6pHg5smb0Gh62t5JrqoGnyxeGXKVcqxA2CbomhtUvfuX6SWLAgdxQVQTs9
+pn0NPRnDP9NfjJqA1NXT5Seq7J/kVwrnngEXJLHotW6Fm7WopmJWXFhNHvH/B8cc
+JXWMvD13tDuZS9hdr4cVdF9vs/RRU+3M5Nh7cZEwOnw9CBSdGWvIDN8lmRsoqZh4
+tSOPXQ9oSAHp0pe3NQvWtIH+EKT3crBcKAbtBn/oHaKAeCFYbludMGOBIMiQ5iqR
+54hYSYOKi39JpqyJUvnc3NzvVfz+3RhxiD/MLddjbQKBgQDZeOMJHi6nQ+oFHtaa
+6QDviM6HHDrHnDOzS1Ruq3MYxvQTrM0jrnHqx99OypHFLhB3t1PbD+CcNB9vVoVR
+eLulTlGCELJP7tnyuh7BJw9zJdK3bPbsuf3id1OQkAf39oJWoH3A2okiMyDy5gCC
+7UORBRVPSSGIcTp78JWCw+5EvwKBgQD8+NO9Bl38R5WztehoC8FLEfxwJ2heXKmI
+A8pBjzbF+pkY/tM8mmqgpbAnp7J7zI+gYQT6APeQBbfgMH14qUQD+mbCY8jQLm4Y
+A1paTGbyQST+oCA9VfIzWVJLIKDjZor5sVZ1KFgI7ZCiPTZJ3/YrV/khdA9vHkPP
+USngD+u3lQKBgFxm1uCa6Gu9mYOPdNPhSLp+QHJ79iW2Iul9imRziLXwYuixNYCB
+sHl3b1SFEabcSbb0ODcN6fu00d52vrK9P82fF1bSTVFVRVmy5zpepFviqEOzkr9G
+z68X0HPOHvSm0v6Htqbos/fKDafnPjRjJ6BIrqM/iXX11kmvEXe8VFL1AoGBANLW
+G7sWPGzPyMAf41QcP/xuQCPFZGII/q7C4eYkE3WL999yOuHunOHJVfim9sXhZu83
+DSvEdJBPg8HRCDHxeSOLpetruOlxWQagfMR3mvFbRBcHo/ca06LiVgkRZ6Y/R6L1
+n2ZDuqOuQ/ZD6CRICeZ0CspL7bUh10hJkAoTmtTFAoGBALKkqAS53PkdyOht9FiY
+s/FjYxXWPbHFRlgt3FQ2BdJ6TwOmqjt7rEYgh+cg5dzIhoo4qeJFAv3nCYRRQ0DC
++yPEvRIRDYBcwF2MeGqpJcF3xe261y96g9wYe8ZyDgA5XMgTrNbhQ+oB1BaAGPza
+FJPoN/LHUij1/uxqbJaC8Wl1
+-----END PRIVATE KEY-----"""
+_certificate = b"""-----BEGIN CERTIFICATE-----
+MIICqjCCAZKgAwIBAgIUK6+7nU9Pfq/630DzjBGJBk2Ou5MwDQYJKoZIhvcNAQEL
+BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMzAzMDgwNTQyMTZaFw0yMzAzMDkwNTQy
+MTZaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDW5mB4IVP4ASCrPKW5vQLAeqDRnpqepjvyqs9rByTNENBzvUUni1jHGAmm
+mT0QweFYaIW7n2CPynN4PJRfmdI2Qkj8w6im0NYKGUYoyKy9XC8WMBqKEFBsFt/B
+yfJYtZncjPYpvBR3jQbZft2FeqNQmUv6GXQA5ul/IifmYnWuDguzlzJklfejOD3Y
+wadMxt7TnMPGxtBpA7IAicheLTFu25GL+KQmOJ5/aaGRgS821SwKAAGAXBvUTAa6
+swREhaxx8eo0qg1B/bJa4BnuMj5y2nxAe1CbiQcOJg09NQcRQFtjBIlr3B6kCLDs
+DfSJffL1sIiHo8tgAtFaDwupJ4wrAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGqx
+yDVtwbfJd0XkWJYq/6jcydDNIrKi7Z290scwJrF+efXoOdFoJnrFj7BylGaClRME
+iI7Xs183kYHVXYjl273Cjw+L/7g51rs1036FCIBtJfYnsCr8VALBOIDgi3UdGDZ9
+/nP3YroMSQePbhhVRRrvQZYlvLintqGKyjPgvPKByhknCkTiSs+Dj2D5LoEJVekh
+z6NdiPcDEOLujFkGpO/I2xDleA8BMcLrNb06Gyww9MWco7I0pK+uNwmIFdF9LSG5
+bzeBEFXommCmyQDDcs1O32twy9RLKzzpWL1yPEHCn8Q91PZ4ZIPqClG/5rOywNS8
+idRhwhpoRZiQXF3im5k=
+-----END CERTIFICATE-----"""
 
-_sig = "pvAdYfF2NtS3Dm8/4zP1vcxs4G6IpApn0Nl0Wg930fJm7uBC7M4E7RdwiMav9UkYVK8cNrNhUnpsWEwX5anE8JOZLnW9JZ8W4a/i8ZFD7KA8PKu6q9I7HxT7eOdjgVUvZkL6j8Jz0Mf97GPc1mpU1Dyvn4qvnXS7iy6g4tuAYeArKYKJHpXqzE3YEoXnnWOwxf44Tw92YVAPO0fvVJUKY2Nt1Om/QX6oZbpwooJN3iBPgu0Zq805d4rT8J01571flyr0+HWPYDN8Q7iPuZC+zPwzyzMFdOyjbS30qRrtvUf/0gDap+s3Kl0U0AiywSrdhzyyc/5cOrOhbEwDu+8+Uw=="
-_cert_der = "MIICqjCCAZKgAwIBAgIUVm184XOVf+ZSmOo+MjOT3MIzdSIwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAxMTUwNzA4MDhaFw0yMDAxMTYwNzA4MDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8IAf7PQxlUTeDZodyCdaTY/XtCNBLI5FNGKgVbjePSDDlsn4nBAtaPemGLNof0lPr4sRjdC5rfwQVtDU21GJMam106RvJcg4eYns51Y2CshDpu6M9Il96Qrp+9djcdbH0MHPsenR+ChTmKa6XYfRkPCO8WIp08Tl39kP0LJNHKcT9OAc6QlS3igcIsL2dkiz6Xq7dVgZ27aViz1pWqdxuqfbSOKQSPqcQRGE8spt9KU+r5UFH4z4ZXGuml/YwscEVKgpzNYdlqE8OpKurm3+pNDuxpbTK+P9Wz0Gq1z5QNP0epaM3bVN0Ft6SH+y+Pyo5ueX7raGB8HXwqgqI6xOBAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAFCbgyUX+Lj2gpx0VqXiYZ8ZCGq644EENsCDHV1fnSq/KuLDuajao6ppEubl5XDs0fba1jy3aJ30H0vuVJ1eLnpOrh/xpAUtpwr9T98kLilRWEGgAKQTl7dilKkYJ1sBA1OUv6ERRt+I7NnMXQvvz2VfevulVHQnO1Reo/QCfMrVdVGTfrYkKRzAnxH/g259+RzpSB9HhQm6oxf8Z4zAPbAJu2mbxI+wcT40Mbw9BhJR/mb1eGMUtetzp7G1btYUtlH4Yix0bP72mabQDIRoQjs8bd2/5nkXLPsCB5nUXp0dbIhYk2Qb0iNgzYdDleLS3pIcEWcj4VxjuYBtQyxhyko="
+_cert_obj = load_pem_x509_certificate(_certificate)
+_cert_der = base64.b64encode(_cert_obj.public_bytes(Encoding.DER))
 
-_signed = lambda sig, cert: (
+
+_dv_1 = b"NFs8b1MQyPBg2GKFQcVNRbhl/ls="
+_sig_1 = b"ZPVR07+ggysYS7lukbteIZA9/3LgdAMpciTxbQc4K+OH1mtXdZ2DX09jqebYf3kdX3t4hpUEGH2w6Xf4LtYENnWpTsmPd86zCXZHkLSwrt+rB/dYMF2aUeDPes2EBEg+f3NMs5eR57VB6t497DVOWpPquaTPKRu1c/RnxIFURCe3vabdr9vwGPeuvlvhSBUdT3+2cED0K/i+AF/q9kNqXv81MdfWMyQmulfmH+UxHvP6oRv1sgyG+RPFiU7fUpBAbM2HTNmQugePhT/kU+62A7Sp1aAMzooH138fTrOwEsGhjzpcPIDkEW49esyerwmnbPWv7brUvb5QRoLLTCOokQ=="
+_dv_256 = b"KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI="
+_sig_256 = b"P1ujK3K+c5TzaSYUVBpHrGgkZmdCSqmDB8aNKV+waTFz2s1A6wtHcrB2Hg2aam/nph8QltKY76yFBNg9E5Xzb47hsX3nssAIy2BFtYFOODVRlxCyY/Mx3OyKijg8GK3w0hsQ0raPcUfhUjGMF+na1J044V5UbeLFi0RsRRPW06PKDtYU4v/ygUmH0YBSrhHgDXBWsq4xhrKefCkeGmSD8cK+16Byg8GdgrbH0KhHEcrjwPjB1G/shsITeVARLg86FvD2eeiTII7nnBSlPxwwoe8xEAaliMW1GSj2PCx8ZVQ7tlzeS6CFmFVh5gBO+lIBW2/36Q9eqkuc0cIsg3WfDw=="
+
+_signed = lambda cert, sig, dv, sma, dma: (
     b'<test:root xmlns:test="urn:test">'
     b'<test:signed ID="test">'
     b'<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">'
     b"<ds:SignedInfo>"
     b'<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:CanonicalizationMethod>'
-    b'<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"></ds:SignatureMethod>'
+    b'<ds:SignatureMethod Algorithm="' + sma + b'"></ds:SignatureMethod>'
     b'<ds:Reference URI="#test">'
     b"<ds:Transforms>"
     b'<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"></ds:Transform>'
     b'<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"></ds:Transform>'
     b"</ds:Transforms>"
-    b'<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"></ds:DigestMethod>'
-    b"<ds:DigestValue>KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI=</ds:DigestValue>"
+    b'<ds:DigestMethod Algorithm="' + dma + b'"></ds:DigestMethod>'
+    b"<ds:DigestValue>" + dv + b"</ds:DigestValue>"
     b"</ds:Reference>"
     b"</ds:SignedInfo>"
     b"<ds:SignatureValue>" + sig + b"</ds:SignatureValue>"
@@ -75,15 +108,67 @@ _signed = lambda sig, cert: (
     b"</test:root>"
 )
 
+_verify_config = VerifyConfig(
+    allowed_digest_method={hashes.SHA1, hashes.SHA256},
+    allowed_signature_method={hashes.SHA1, hashes.SHA256},
+)
 
-def _pretty_b64(val: str) -> bytes:
-    return b"\n".join(map(str.encode, textwrap.wrap(val, width=79)))
+
+def _pretty_b64(val: bytes) -> bytes:
+    return b"\n".join(map(str.encode, textwrap.wrap(val.decode(), width=79)))
+
+
+@dataclass
+class AlgorithmConfig:
+    sma_uri: bytes
+    dma_uri: bytes
+    sv: bytes
+    dv: bytes
+
+
+_values = {
+    (1, 1): AlgorithmConfig(
+        b"http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+        b"http://www.w3.org/2000/09/xmldsig#sha1",
+        b"ZPVR07+ggysYS7lukbteIZA9/3LgdAMpciTxbQc4K+OH1mtXdZ2DX09jqebYf3kdX3t4hpUEGH2w6Xf4LtYENnWpTsmPd86zCXZHkLSwrt+rB/dYMF2aUeDPes2EBEg+f3NMs5eR57VB6t497DVOWpPquaTPKRu1c/RnxIFURCe3vabdr9vwGPeuvlvhSBUdT3+2cED0K/i+AF/q9kNqXv81MdfWMyQmulfmH+UxHvP6oRv1sgyG+RPFiU7fUpBAbM2HTNmQugePhT/kU+62A7Sp1aAMzooH138fTrOwEsGhjzpcPIDkEW49esyerwmnbPWv7brUvb5QRoLLTCOokQ==",
+        b"NFs8b1MQyPBg2GKFQcVNRbhl/ls=",
+    ),
+    (1, 256): AlgorithmConfig(
+        b"http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+        b"http://www.w3.org/2001/04/xmlenc#sha256",
+        b"loMxA3k3/8fXT10omi0U5kInJGmqpR4n7W25SqGK6mD5cvs+mhSDYOeQuhFWiF92J4l2enO5yMiEAW0F7XRmIMDVjl9p3nwMrkPGurRT52ycCAb5ycGp15ooOV8M+tsJRuyp73hLnbHmK26VZtkQMunmgJDIlBxoYdPSfjdEl8k+AujpEokT/iyQ9CobPjsO7RfGn6bJNpxTZo/HlkhKF07oYbqWrci2AXUn4/18bur6hXbdfbmGfBfFxYZKuoaB1CFKAfIAmxMIEBNluGxNsYyEx5hE78X/97j1popW6lRv4h5GsBqNxlITbpRonVKreLxPcsHMYo2lT2GeUym1Cg==",
+        b"KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI=",
+    ),
+    (256, 1): AlgorithmConfig(
+        b"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        b"http://www.w3.org/2000/09/xmldsig#sha1",
+        b"isEnIga7ISY+sR9AaR3xJFqtDTMVX9OpNNOT7xqMekMFTkpHQtL6Hgik4CQdM86B1TGHHIcg2UIa3pqQnUxRfSx0/PK7mSYKeCvshrOHCHpnaP4ZkdLCPunYfrVG1Z/VvJobdqtDR84TQQNnNF+GOrvgtg7MWeHg+ZqRGQpW4x1Ose3VKCi2PKh8fq/zeH2K8kmft4iLWakYPwAW3hlLurw2Z8Fo/ULZqLxmC9ZOWAyOjeDhSYngnPPO3A0QUC2f6Z87zJFel7Y86iM5UcRerIp0AjuGOKBfnBX+dOyY12ixd/YEwEmnkyLocqG+5sZ/ezMBRGcUaUIalQN3TxLBsA==",
+        b"NFs8b1MQyPBg2GKFQcVNRbhl/ls=",
+    ),
+    (256, 256): AlgorithmConfig(
+        b"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        b"http://www.w3.org/2001/04/xmlenc#sha256",
+        b"P1ujK3K+c5TzaSYUVBpHrGgkZmdCSqmDB8aNKV+waTFz2s1A6wtHcrB2Hg2aam/nph8QltKY76yFBNg9E5Xzb47hsX3nssAIy2BFtYFOODVRlxCyY/Mx3OyKijg8GK3w0hsQ0raPcUfhUjGMF+na1J044V5UbeLFi0RsRRPW06PKDtYU4v/ygUmH0YBSrhHgDXBWsq4xhrKefCkeGmSD8cK+16Byg8GdgrbH0KhHEcrjwPjB1G/shsITeVARLg86FvD2eeiTII7nnBSlPxwwoe8xEAaliMW1GSj2PCx8ZVQ7tlzeS6CFmFVh5gBO+lIBW2/36Q9eqkuc0cIsg3WfDw==",
+        b"KeOO+93WmuoCL8Ci/llQH18tFfzI81ihpZCiJv0q8EI=",
+    ),
+}
+
+
+@pytest.fixture(scope="session", params=itertools.product([1, 256], [1, 256]), ids=repr)
+def algorithm_config(request) -> AlgorithmConfig:
+    return _values[request.param]
 
 
 @pytest.fixture(scope="session", params=[True, False])
-def cert_and_signed(request) -> Tuple[Certificate, bytes]:
-    transform = _pretty_b64 if request.param else str.encode
-    return _cert_obj, _signed(transform(_sig), transform(_cert_der))
+def cert_and_signed(algorithm_config, request) -> Tuple[Certificate, bytes]:
+    transform = _pretty_b64 if request.param else lambda x: x
+    return _cert_obj, _signed(
+        transform(_cert_der),
+        transform(algorithm_config.sv),
+        algorithm_config.dv,
+        algorithm_config.sma_uri,
+        algorithm_config.dma_uri,
+    )
 
 
 def test_verify(xmlsec1, tmp_path, cert_and_signed):
@@ -105,7 +190,11 @@ def test_verify(xmlsec1, tmp_path, cert_and_signed):
         str(signed),
     )
 
-    verified_element = extract_verified_element(xml=xml, certificate=cert)
+    verified_element = extract_verified_element(
+        xml=xml,
+        certificate=cert,
+        config=_verify_config,
+    )
     assert verified_element is not None
     assert verified_element.tag == "{urn:test}signed"
     assert verified_element.attrib["ID"] == "test"
@@ -118,7 +207,7 @@ def test_verify_fail(cert_and_signed):
         b"<test:content>Changed Value</test:content>",
     )
     with pytest.raises(VerificationFailed):
-        extract_verified_element(xml=broken, certificate=cert)
+        extract_verified_element(xml=broken, certificate=cert, config=_verify_config)
 
 
 def test_verify_config(key_and_cert):
@@ -193,7 +282,7 @@ def test_verification_failed(cert_and_signed):
     signature_value.text = "x" + signature_value.text
     xml = utils.serialize_xml(root)
     with pytest.raises(VerificationFailed):
-        extract_verified_element(xml=xml, certificate=cert)
+        extract_verified_element(xml=xml, certificate=cert, config=_verify_config)
 
 
 def test_verification_failed2(cert_and_signed):
@@ -203,7 +292,7 @@ def test_verification_failed2(cert_and_signed):
     signature_value.text = signature_value.text + "x"
     xml = utils.serialize_xml(root)
     with pytest.raises(binascii.Error):
-        extract_verified_element(xml=xml, certificate=cert)
+        extract_verified_element(xml=xml, certificate=cert, config=_verify_config)
 
 
 def test_extract_verified_element_and_certificate(cert_and_signed, key_factory):
@@ -211,7 +300,9 @@ def test_extract_verified_element_and_certificate(cert_and_signed, key_factory):
     correct_cert, xml = cert_and_signed
 
     verified_element, used_certificate = extract_verified_element_and_certificate(
-        xml=xml, certificates={incorrect_cert, correct_cert}
+        xml=xml,
+        certificates={incorrect_cert, correct_cert},
+        config=_verify_config,
     )
     assert used_certificate == correct_cert
     assert verified_element is not None
@@ -224,6 +315,8 @@ def test_extract_verified_element_and_certificate_fail(cert_and_signed, key_fact
     correct_cert, xml = cert_and_signed
 
     with pytest.raises(CertificateMismatch) as exc:
-        extract_verified_element_and_certificate(xml=xml, certificates={incorrect_cert})
+        extract_verified_element_and_certificate(
+            xml=xml, certificates={incorrect_cert}, config=_verify_config
+        )
     assert exc.value.received_certificate == correct_cert
     assert exc.value.expected_certificates == {incorrect_cert}


### PR DESCRIPTION
Verification with SHA1 Signature Method would fail due to `minisignxml.internal.utils.signature_method_hasher` checking for the wrong constant.

The various other changes are done to make code checking/tests/ci work properly.