### PR TITLE
Fix warning triggered by `assert parent`

### DIFF
--- a/src/minisignxml/internal/utils.py
+++ b/src/minisignxml/internal/utils.py
@@ -116,7 +116,7 @@ def get_root(element: Element) -> Element:
 
 def remove_preserving_whitespace(element: Element) -> None:
     parent = element.getparent()
-    assert parent
+    assert parent is not None
     if element.tail:
         prev = element.getprevious()
         if prev is not None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from minisignxml.internal import utils
 def test_remove_element(input, output):
     tree = utils.deserialize_xml(input)
     element = tree.find("remove")
+    assert element is not None
     utils.remove_preserving_whitespace(element)
     result = utils.serialize_xml(tree)
     assert result == output


### PR DESCRIPTION
_**Running on Python 3.11**_

This is a minor fix to suppress the following warning from the `lxml` library.
```
minisignxml/internal/utils.py:119:FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```
